### PR TITLE
udev: make uaccess take effect and cleanup

### DIFF
--- a/69-hslink.rules
+++ b/69-hslink.rules
@@ -24,7 +24,7 @@ SUBSYSTEM!="usb|tty|hidraw", GOTO="hslink_rules_end"
 # Please keep this list sorted by VID:PID
 
 # HSLinkPro
-ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", MODE="666", ENV{ID_DEBUG_APPLIANCE}="hslink", SYMLINK+="HSLink_%n"
+ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", ENV{ID_DEBUG_APPLIANCE}="hslink", SYMLINK+="HSLink_%n"
 
 # TODO: For compatible with systemd < v258
 ENV{ID_DEBUG_APPLIANCE}=="hslink", TAG+="uaccess"

--- a/69-hslink.rules
+++ b/69-hslink.rules
@@ -3,7 +3,7 @@
 # HSLinkPro boards, https://github.com/HSLink/HSLink_Hardware
 # HSLinkPro firmware, https://github.com/cherry-embedded/CherryDAP/releases
 
-# Copy this file to /etc/udev/rules.d/
+# Copy this file to /etc/udev/rules.d/, ensure the order number SHALL less than 70.
 # If rules fail to reload automatically, you can refresh udev rules
 # with the command "udevadm control --reload"
 

--- a/69-hslink.rules
+++ b/69-hslink.rules
@@ -24,6 +24,11 @@ SUBSYSTEM!="usb|tty|hidraw", GOTO="hslink_rules_end"
 # Please keep this list sorted by VID:PID
 
 # HSLinkPro
-ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", MODE="666", TAG+="uaccess", SYMLINK+="HSLink_%n"
+ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", MODE="666", ENV{ID_DEBUG_APPLIANCE}="hslink", SYMLINK+="HSLink_%n"
+
+# TODO: For compatible with systemd < v258
+ENV{ID_DEBUG_APPLIANCE}=="hslink", TAG+="uaccess"
+# If you want to use HSLink with SSH-login user session, uncomment line below, and replace grpname with what you want.
+#ENV{ID_DEBUG_APPLIANCE}=="hslink", MODE="0660", GROUP="grpname"
 
 LABEL="hslink_rules_end"

--- a/99-hslink.rules
+++ b/99-hslink.rules
@@ -11,16 +11,6 @@
 #   sudo udevadm control --reload-rules
 #   sudo udevadm trigger
 
-# The device group for newer versions of Linux such as Arch is uucp.
-# sudo usermod -aG uucp $USER
-# or
-# sudo gpasswd -a $USER uucp
-
-# Older Linux device groups such as Ubuntu are plugdev
-# sudo usermod -aG plugdev $USER
-# or
-# sudo gpasswd -a $USER plugdev
-
 ACTION!="add|change", GOTO="hslink_rules_end"
 
 SUBSYSTEM=="gpio", MODE="0660", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you are using a repository-compiled deb or rpm package, you need to install 9
 
 ```bash
 cd /usr/lib/hslink-nexus
-sudo install -Dvm644 99-hslink.rules -t /usr/lib/udev/rules.d/
+sudo install -Dvm644 69-hslink.rules -t /usr/lib/udev/rules.d/
 ```
 
 If rules fail to reload automatically, you can refresh udev rules with the command "udevadm control --reload"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       "../public/HSLink.svg"
     ],
     "resources": {
-      "../99-hslink.rules": "99-hslink.rules",
+      "../69-hslink.rules": "69-hslink.rules",
       "../LICENSE": "LICENSE",
       "../README.md": "README.md"
     },


### PR DESCRIPTION
In systemd upstream, the TAG+="uaccess" is set in 70-uaccess.rules, and
were used in 71-seat.rules and 73-seat-late.rules, so it SHALL be less
than 70 to take effect.

See [1], generic device class is the recommended way to set permission
for debug probe. Unfortunately, the device class ID_DEBUG_APPLIANCE was
introduced in systemd v258. So I use a trick to be compatible with older
systemd: in older version, it will set uaccess for ENV{ID_DEBUG_APPLIANCE}=="hslink",
in systemd>=258, it do redundant operation, but since TAG+= is
idempotent, it's safe.

[1]: https://gitlab.archlinux.org/archlinux/packaging/packages/probe-rs/-/issues/4

Signed-off-by: Coelacanthus <uwu@coelacanthus.name>